### PR TITLE
refs #227 destroy_investment!の削除（再適用）

### DIFF
--- a/app/controllers/bs/investments_controller.rb
+++ b/app/controllers/bs/investments_controller.rb
@@ -2,7 +2,7 @@ class Bs::InvestmentsController < Base::HyaccController
   include BankAccountsAware
 
   view_attribute :customers, only: [:new,:create,:edit,:update], conditions: {is_investment: true, deleted: false}
-  helper_method :finder
+  helper_method :finder, :index_query_params
 
   def index
     @investments = finder.list if params[:commit]
@@ -55,7 +55,7 @@ class Bs::InvestmentsController < Base::HyaccController
       redirect_to :action => :index
     rescue => e
       handle(e)
-      redirect_to :action => :index
+      redirect_to :action => :index, params: index_query_params
     end
   end
 
@@ -74,6 +74,18 @@ class Bs::InvestmentsController < Base::HyaccController
 
   def finder_params
     params.fetch(:finder, {}).permit(:fiscal_year, :bank_account_id)
+  end
+
+  def index_query_params
+    p = {}
+    p[:commit] = params[:commit] if params[:commit].present?
+    if params[:finder].present?
+      p[:finder] = {
+        fiscal_year: params[:finder][:fiscal_year],
+        bank_account_id: params[:finder][:bank_account_id]
+      }.compact
+    end
+    p
   end
 
   def investment_params

--- a/app/utils/hyacc_errors.rb
+++ b/app/utils/hyacc_errors.rb
@@ -25,6 +25,7 @@ module HyaccErrors
   ERR_INVALID_TAX_TYPE = "不正な消費税区分です。"
   ERR_ILLEGAL_STATE = "予期せぬ状態です。"
   ERR_ILLEGAL_TAX_DETAIL = "消費税は税抜経理方式の場合のみ指定可能です。"
+  ERR_INVESTMENT_UNLINK_REQUIRED = "有価証券以外の伝票に紐づいているため削除できません。"
   ERR_NO_CAPITATION_TARGET_BRANCH_EXISTS = "人頭割で配賦できる部門がありません。"
   ERR_NOT_JOURNALIZABLE_ACCOUNT = "仕訳が登録できない勘定科目が指定されています。"
   ERR_OVERRIDE_NEEDED = "サブクラスでの実装が必要です。"

--- a/app/views/bs/investments/index.html.erb
+++ b/app/views/bs/investments/index.html.erb
@@ -1,7 +1,6 @@
 <%= render 'search' %>
-<% if @investments %>
 <%= render 'common/message' %>
-
+<% if @investments %>
 <div class="col-md-8">
   <table class="table table-striped table-hover">
     <thead>
@@ -26,7 +25,7 @@
           <td class="right"><%= '△' if inv.selling? %><%= to_amount(inv.trading_value + inv.gains) %></td>
           <td class="center">
             <%= link_to '編集', edit_bs_investment_path(inv), remote: true, class: 'btn btn-light btn-sm' %>
-            <%= link_to '削除', bs_investment_path(inv),
+            <%= link_to '削除', bs_investment_path(inv, index_query_params),
                   data: {confirm: '伝票を削除します。よろしいですか？'}, method: :delete, class: 'btn btn-light btn-sm' %>
           </td>
         </tr>
@@ -41,4 +40,6 @@
     </tfoot>
   </table>
 </div>
+<% else %>
+<div class="col-md-8"></div>
 <% end %>

--- a/test/models/investment_test.rb
+++ b/test/models/investment_test.rb
@@ -72,4 +72,13 @@ class InvestmentTest < ActiveSupport::TestCase
     end
   end
 
+  def test_有価証券以外の伝票に紐づいているときは削除できない
+    investment = Investment.find(2)
+    jh = Journal.where.not(slip_type: SLIP_TYPE_INVESTMENT).first
+    jh.update_column(:investment_id, investment.id)
+
+    assert_raises(HyaccException) { investment.destroy }
+    assert Investment.exists?(investment.id)
+  end
+
 end


### PR DESCRIPTION
rakeタスク(hyacc:investment:unlink_non_investment_journals)マージ後に再適用。 紐付け解除はタスクに任せるため @investment.destroy! に統一。