### PR TITLE
refs #264 従業員マスタ拡張（full_time/duty_description/relationship）

### DIFF
--- a/app/controllers/mm/employees_controller.rb
+++ b/app/controllers/mm/employees_controller.rb
@@ -104,6 +104,7 @@ class Mm::EmployeesController < Base::HyaccController
     permitted = [
       :first_name, :last_name, :first_name_kana, :last_name_kana, :employment_date, :retirement_date,
       :sex, :business_office_id, :birth, :my_number, :social_insurance_reference_number, :executive, :position,
+      :full_time, :duty_description, :relationship_to_representative,
       :num_of_dependent, :num_of_dependent_effective_at,
       :zip_code, :zip_code_effective_at,
       :address, :address_effective_at,

--- a/app/views/mm/employees/_evaluation.html.erb
+++ b/app/views/mm/employees/_evaluation.html.erb
@@ -16,5 +16,19 @@
       <th><%= f.label :position %></th>
       <td><%= f.text_field :position %></td>
     </tr>
+    <tr>
+      <th><%= f.label :full_time %></th>
+      <td>
+        <%= f.select :full_time, [['常勤', 'true'], ['非常勤', 'false']], { include_blank: true } %>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :duty_description %></th>
+      <td><%= f.text_field :duty_description %></td>
+    </tr>
+    <tr>
+      <th><%= f.label :relationship_to_representative %></th>
+      <td><%= f.text_field :relationship_to_representative %></td>
+    </tr>
   </table>
 <% end %>

--- a/app/views/mm/employees/_show.html.erb
+++ b/app/views/mm/employees/_show.html.erb
@@ -83,6 +83,21 @@
     </p>
 
     <p>
+      <b><%= @e.class.human_attribute_name :full_time %>:</b>
+      <%= @e.full_time.nil? ? '' : (@e.full_time ? '常勤' : '非常勤') %>
+    </p>
+
+    <p>
+      <b><%= @e.class.human_attribute_name :duty_description %>:</b>
+      <%= @e.duty_description %>
+    </p>
+
+    <p>
+      <b><%= @e.class.human_attribute_name :relationship_to_representative %>:</b>
+      <%= @e.relationship_to_representative %>
+    </p>
+
+    <p>
       <b>退職金積立開始時期:</b>
       <%= get_start_ym_of_retirement_savings(@e) %>
     </p>

--- a/config/locales/hyacc.ja.yml
+++ b/config/locales/hyacc.ja.yml
@@ -140,17 +140,20 @@ ja:
         base_salary: 基本給
         birth: 生年月日
         business_office_id: 所属する事業所
+        duty_description: 担当業務
         employment_date: 入社日
         retirement_date: 退社日
         executive: 雇用形態
         executive_true: 役員
         executive_false: 従業員
         first_name: 名
+        full_time: 常勤／非常勤
         last_name: 姓
         my_number: マイナンバー
         name_kana: 姓名（カナ）
         num_of_dependent: 扶養親族等の数
         position: 役職
+        relationship_to_representative: 代表者との関係
         sex: 性別
         social_insurance_birthday: 被保険者生年月日
         social_insurance_reference_number: 被保険者整理番号

--- a/db/migrate/20260325161640_add_column_full_time_on_employees.rb
+++ b/db/migrate/20260325161640_add_column_full_time_on_employees.rb
@@ -1,0 +1,6 @@
+class AddColumnFullTimeOnEmployees < ActiveRecord::Migration[8.1]
+  def change
+    add_column :employees, :full_time, :boolean
+  end
+end
+

--- a/db/migrate/20260325161641_add_column_duty_description_on_employees.rb
+++ b/db/migrate/20260325161641_add_column_duty_description_on_employees.rb
@@ -1,0 +1,6 @@
+class AddColumnDutyDescriptionOnEmployees < ActiveRecord::Migration[8.1]
+  def change
+    add_column :employees, :duty_description, :string
+  end
+end
+

--- a/db/migrate/20260325161642_add_column_relationship_to_representative_on_employees.rb
+++ b/db/migrate/20260325161642_add_column_relationship_to_representative_on_employees.rb
@@ -1,0 +1,6 @@
+class AddColumnRelationshipToRepresentativeOnEmployees < ActiveRecord::Migration[8.1]
+  def change
+    add_column :employees, :relationship_to_representative, :string
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_22_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_161642) do
   create_table "accounts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "account_type", null: false
     t.string "code", default: "", null: false
@@ -312,15 +312,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_22_000000) do
     t.datetime "created_at", precision: nil
     t.boolean "deleted", default: false, null: false
     t.boolean "disabled", default: false, null: false
+    t.string "duty_description"
     t.date "employment_date", null: false
     t.boolean "executive", default: false, null: false
     t.string "first_name", null: false
     t.string "first_name_kana"
+    t.boolean "full_time"
     t.string "last_name", null: false
     t.string "last_name_kana"
     t.string "my_number", limit: 12
     t.integer "num_of_dependent", default: 0, null: false
     t.string "position"
+    t.string "relationship_to_representative"
     t.date "retirement_date"
     t.string "sex", limit: 1, null: false
     t.integer "social_insurance_reference_number"

--- a/test/controllers/mm/employees_controller_test.rb
+++ b/test/controllers/mm/employees_controller_test.rb
@@ -28,6 +28,11 @@ class Mm::EmployeesControllerTest < ActionController::TestCase
     post :create, params: {employee: employee_params}, xhr: true
     assert_response :success
     assert_template 'common/reload'
+
+    e = assigns(:e)
+    assert_equal employee_params[:full_time], e.full_time
+    assert_equal employee_params[:duty_description], e.duty_description
+    assert_equal employee_params[:relationship_to_representative], e.relationship_to_representative
   end
 
   def test_編集
@@ -49,6 +54,11 @@ class Mm::EmployeesControllerTest < ActionController::TestCase
     patch :update, params: {id: employee.id, employee: employee_params}, xhr: true
     assert_response :success
     assert_template 'common/reload'
+
+    e = assigns(:e)
+    assert_equal employee_params[:full_time], e.full_time
+    assert_equal employee_params[:duty_description], e.duty_description
+    assert_equal employee_params[:relationship_to_representative], e.relationship_to_representative
   end
 
   def test_更新_入力エラー

--- a/test/support/employees.rb
+++ b/test/support/employees.rb
@@ -26,7 +26,10 @@ module Employees
       zip_code_effective_at: Date.today - 3.years,
       address: '北海道札幌市',
       address_effective_at: Date.today - 3.years,
-      position: '代表取締役'
+      position: '代表取締役',
+      full_time: options.fetch(:full_time, true),
+      duty_description: options[:duty_description] || '担当業務テスト',
+      relationship_to_representative: options[:relationship_to_representative] || '本人'
     }
   end
   


### PR DESCRIPTION
- full_time/duty_description/relationshipカラムをEmployeeに追加
- 登録・編集UIに入力項目を反映し、保存/更新できることをテストで確認