### PR TITLE
test(payroll_notification): Processor テストで travel_to により基準日を固定

### DIFF
--- a/test/services/payroll_notification/payroll_notification_processor_test.rb
+++ b/test/services/payroll_notification/payroll_notification_processor_test.rb
@@ -4,7 +4,9 @@ require 'minitest/mock'
 class PayrollNotificationProcessorTest < ActiveSupport::TestCase
 
   def setup
+    @_payroll_notification_time_travel = false
     travel_to Time.zone.local(2025, 8, 15)
+    @_payroll_notification_time_travel = true
 
     @employee8 = Employee.find(8)
     BankAccount.second.update!(company_id: @employee8.company.id, for_payroll: true)
@@ -31,10 +33,14 @@ class PayrollNotificationProcessorTest < ActiveSupport::TestCase
       update_user_id: employee1.user.id,
       is_bonus: false
     )
+  rescue StandardError
+    travel_back if @_payroll_notification_time_travel
+    @_payroll_notification_time_travel = false
+    raise
   end
 
   def teardown
-    travel_back
+    travel_back if @_payroll_notification_time_travel
   end
 
   def test_処理対象に関するログを出力する


### PR DESCRIPTION
Date.current 依存で新年度以降に会計年度解決に失敗するため、2025-08-15 に固定する。