### PR TITLE
test: 住民税削除後のリダイレクト年度をtravel_toで固定

### DIFF
--- a/test/controllers/mm/inhabitant_taxes_controller_test.rb
+++ b/test/controllers/mm/inhabitant_taxes_controller_test.rb
@@ -63,12 +63,15 @@ class Mm::InhabitantTaxesControllerTest < ActionController::TestCase
 
   def test_削除
     sign_in admin
-    expected_year = InhabitantTaxFinder.new.year
 
-    assert_difference('InhabitantTax.count', -1) do
-      delete :destroy, :params => {:id => InhabitantTax.first.id}
+    travel_to Time.zone.local(2026, 6, 15) do
+      expected_year = InhabitantTaxFinder.new.year
+
+      assert_difference('InhabitantTax.count', -1) do
+        delete :destroy, :params => {:id => InhabitantTax.first.id}
+      end
+      assert_redirected_to :action => 'index', finder: { year: expected_year }
     end
-    assert_redirected_to :action => 'index', finder: { year: expected_year }
   end
   
 end

--- a/test/controllers/mm/inhabitant_taxes_controller_test.rb
+++ b/test/controllers/mm/inhabitant_taxes_controller_test.rb
@@ -63,10 +63,12 @@ class Mm::InhabitantTaxesControllerTest < ActionController::TestCase
 
   def test_削除
     sign_in admin
+    expected_year = InhabitantTaxFinder.new.year
+
     assert_difference('InhabitantTax.count', -1) do
       delete :destroy, :params => {:id => InhabitantTax.first.id}
     end
-    assert_redirected_to :action => 'index', finder: { year: 2025 }
+    assert_redirected_to :action => 'index', finder: { year: expected_year }
   end
   
 end


### PR DESCRIPTION
6月以降は `InhabitantTaxFinder#year` のデフォルトが切り替わるため、`test_削除` の `year: 2025` 固定が失敗していた。
`travel_to`で年度を固定の上、コントローラと同じ算出結果を `expected_year` として使い、毎年の手動での更新を不要にする。