### PR TITLE
refs #361 最後のログイン可能な管理権限ユーザーの削除・無効化を防止

### DIFF
--- a/app/controllers/mm/employees_controller.rb
+++ b/app/controllers/mm/employees_controller.rb
@@ -60,31 +60,42 @@ class Mm::EmployeesController < Base::HyaccController
   def disable
     @employee = Employee.find(params[:id])
     @employee.disabled = true
-    
-    @employee.transaction do
-      @employee.save!
-    end
+
+    begin
+      @employee.transaction do
+        @employee.save!
+      end
 
     # 無効にしたユーザがログインユーザ自身の場合は、ログアウト
-    if current_user.employee.id == @employee.id
-      reset_session
-      redirect_to root_path
-    else
-      flash[:notice] = "#{@employee.name} を無効にしました。"
+      if current_user.employee.id == @employee.id
+        redirect_to new_user_session_path
+      else
+        flash[:notice] = "#{@employee.name} を無効にしました。"
+        redirect_to action: :index
+      end
+    rescue => e
+      handle(e)
       redirect_to action: :index
     end
   end
 
   def destroy
     @employee = Employee.find(params[:id])
-    @employee.destroy_logically!
+
+    begin
+      @employee.transaction do
+        @employee.destroy_logically!
+      end
 
     # 削除したユーザがログインユーザ自身の場合は、ログアウト
-    if current_user.employee.id == @employee.id
-      reset_session
-      redirect_to root_path
-    else
-      flash[:notice] = "#{@employee.name} を削除しました。"
+      if current_user.employee.id == @employee.id
+        redirect_to new_user_session_path
+      else
+        flash[:notice] = "#{@employee.name} を削除しました。"
+        redirect_to action: :index
+      end
+    rescue => e
+      handle(e)
       redirect_to action: :index
     end
   end

--- a/app/controllers/mm/employees_controller.rb
+++ b/app/controllers/mm/employees_controller.rb
@@ -69,7 +69,7 @@ class Mm::EmployeesController < Base::HyaccController
     # 無効にしたユーザがログインユーザ自身の場合は、ログアウト
       if current_user.employee.id == @employee.id
         reset_session
-        redirect_to new_user_session_path
+        redirect_to root_path
       else
         flash[:notice] = "#{@employee.name} を無効にしました。"
         redirect_to action: :index
@@ -91,7 +91,7 @@ class Mm::EmployeesController < Base::HyaccController
     # 削除したユーザがログインユーザ自身の場合は、ログアウト
       if current_user.employee.id == @employee.id
         reset_session
-        redirect_to new_user_session_path
+        redirect_to root_path
       else
         flash[:notice] = "#{@employee.name} を削除しました。"
         redirect_to action: :index

--- a/app/controllers/mm/employees_controller.rb
+++ b/app/controllers/mm/employees_controller.rb
@@ -68,6 +68,7 @@ class Mm::EmployeesController < Base::HyaccController
 
     # 無効にしたユーザがログインユーザ自身の場合は、ログアウト
       if current_user.employee.id == @employee.id
+        reset_session
         redirect_to new_user_session_path
       else
         flash[:notice] = "#{@employee.name} を無効にしました。"
@@ -89,6 +90,7 @@ class Mm::EmployeesController < Base::HyaccController
 
     # 削除したユーザがログインユーザ自身の場合は、ログアウト
       if current_user.employee.id == @employee.id
+        reset_session
         redirect_to new_user_session_path
       else
         flash[:notice] = "#{@employee.name} を削除しました。"

--- a/app/controllers/mm/users_controller.rb
+++ b/app/controllers/mm/users_controller.rb
@@ -64,6 +64,7 @@ class Mm::UsersController < Base::HyaccController
 
     # 削除したユーザがログインユーザ自身の場合は、ログアウト
       if current_user.id == id
+        reset_session
         redirect_to new_user_session_path
       else
         flash[:notice] = 'ユーザを削除しました。'

--- a/app/controllers/mm/users_controller.rb
+++ b/app/controllers/mm/users_controller.rb
@@ -55,13 +55,22 @@ class Mm::UsersController < Base::HyaccController
 
   def destroy
     id = params[:id].to_i
-    User.find(id).destroy_logically!
+    user = User.find(id)
+
+    begin
+      user.transaction do
+        user.destroy_logically!
+      end
 
     # 削除したユーザがログインユーザ自身の場合は、ログアウト
-    if current_user.id == id
-      redirect_to new_user_session_path
-    else
-      flash[:notice] = 'ユーザを削除しました。'
+      if current_user.id == id
+        redirect_to new_user_session_path
+      else
+        flash[:notice] = 'ユーザを削除しました。'
+        redirect_to action: :index
+      end
+    rescue => e
+      handle(e)
       redirect_to action: :index
     end
   end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -25,6 +25,7 @@ class Employee < ApplicationRecord
 
   validates_with Validators::DefaultBranchPresenceValidator
   validates_with Validators::UniqueBranchEmployeesValidator
+  validates_with Validators::LastActiveAdminValidator
 
   def self.name_is(name)
     where('last_name = ? or first_name = ? or concat(last_name, first_name) = ?', name, name, name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   validates_format_of :password, with: /\A[!-~]*\z/, allow_blank: true  
   validates_format_of :google_account, allow_nil: true, allow_blank: true, with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\z/
 
+  validates_with Validators::LastActiveAdminValidator
+
   has_one :employee
   accepts_nested_attributes_for :employee
 
@@ -14,6 +16,26 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :simple_slip_settings, allow_destroy: true
 
   has_many :user_notifications
+
+  scope :active_admins, -> {
+    joins(:employee).where(
+      admin: true, deleted: false,
+      employees: { disabled: false, deleted: false }
+    )
+  }
+
+  def active_admin?
+    admin? && !deleted? && !employee.disabled? && !employee.deleted?
+  end
+
+  def would_remove_last_active_admin?
+    return false unless admin?
+    return false if deleted_in_database
+    return false if employee.deleted_in_database || employee.disabled_in_database
+
+    company_active_admins = self.class.active_admins.where(employees: { company_id: employee.company_id })
+    company_active_admins.where.not(id: id).none?
+  end
 
   def active_for_authentication?
     return false if deleted? || employee.disabled? || employee.deleted?

--- a/app/models/validators/last_active_admin_validator.rb
+++ b/app/models/validators/last_active_admin_validator.rb
@@ -1,0 +1,44 @@
+module Validators
+
+  class LastActiveAdminValidator < ActiveModel::Validator
+
+    def validate(record)
+      case record
+      when User
+        validate_user(record)
+      when Employee
+        validate_employee(record)
+      else
+        raise ArgumentError,
+              "LastActiveAdminValidator: #{record.class.name} は対応外です"
+      end
+    end
+
+    private
+
+    def validate_user(user)
+      return unless user.will_save_change_to_deleted? && user.deleted?
+      return unless user.would_remove_last_active_admin?
+
+      user.errors.add(:base, HyaccErrors::ERR_LAST_ACTIVE_ADMIN_DELETE)
+    end
+
+    def validate_employee(employee)
+      user = employee.user
+      return unless user
+
+      becoming_inactive = (employee.will_save_change_to_disabled? && employee.disabled?) ||
+                          (employee.will_save_change_to_deleted? && employee.deleted?)
+      return unless becoming_inactive
+      return unless user.would_remove_last_active_admin?
+
+      error = if employee.will_save_change_to_disabled? && employee.disabled?
+                HyaccErrors::ERR_LAST_ACTIVE_ADMIN_DISABLE
+              else
+                HyaccErrors::ERR_LAST_ACTIVE_ADMIN_DELETE
+              end
+      employee.errors.add(:base, error)
+    end
+
+  end
+end

--- a/app/utils/hyacc_errors.rb
+++ b/app/utils/hyacc_errors.rb
@@ -28,6 +28,8 @@ module HyaccErrors
   ERR_INVALID_TAX_TYPE = "不正な消費税区分です。"
   ERR_ILLEGAL_STATE = "予期せぬ状態です。"
   ERR_ILLEGAL_TAX_DETAIL = "消費税は税抜経理方式の場合のみ指定可能です。"
+  ERR_LAST_ACTIVE_ADMIN_DELETE = "ログイン可能な管理権限を持つユーザーが0人になるため、削除できません。"
+  ERR_LAST_ACTIVE_ADMIN_DISABLE = "ログイン可能な管理権限を持つユーザーが0人になるため、無効にできません。"
   ERR_NO_CAPITATION_TARGET_BRANCH_EXISTS = "人頭割で配賦できる部門がありません。"
   ERR_NOT_JOURNALIZABLE_ACCOUNT = "仕訳が登録できない勘定科目が指定されています。"
   ERR_OVERRIDE_NEEDED = "サブクラスでの実装が必要です。"

--- a/test/controllers/mm/employees_controller_test.rb
+++ b/test/controllers/mm/employees_controller_test.rb
@@ -111,7 +111,7 @@ class Mm::EmployeesControllerTest < ActionController::TestCase
     sign_in admin
     post :disable, params: {id: admin.employee.id}
 
-    assert_redirected_to new_user_session_path
+    assert_redirected_to root_path
     assert admin.employee.reload.disabled?
   end
 
@@ -122,7 +122,7 @@ class Mm::EmployeesControllerTest < ActionController::TestCase
     sign_in admin
     delete :destroy, params: {id: admin.employee.id}
 
-    assert_redirected_to new_user_session_path
+    assert_redirected_to root_path
     assert admin.employee.reload.deleted?
   end
 

--- a/test/controllers/mm/employees_controller_test.rb
+++ b/test/controllers/mm/employees_controller_test.rb
@@ -73,7 +73,6 @@ class Mm::EmployeesControllerTest < ActionController::TestCase
   def test_無効
     sign_in admin
     post :disable, params: {id: employee.id}
-    assert_response :redirect
     assert_redirected_to action: 'index'
   end
 
@@ -82,15 +81,71 @@ class Mm::EmployeesControllerTest < ActionController::TestCase
 
     sign_in admin
     delete :destroy, params: {id: @employee.id}
-    assert_response :redirect
     assert_redirected_to action: 'index'
   end
 
-  def test_自分を削除
+  def test_ログイン可能な管理権限を持つユーザーが1人のとき_自分自身を無効にできない
+    sign_in admin
+    post :disable, params: {id: admin.employee.id}
+
+    assert_redirected_to action: 'index'
+    assert_not admin.employee.reload.disabled?
+    assert flash[:is_error_message]
+    assert_equal ERR_LAST_ACTIVE_ADMIN_DISABLE, flash[:notice]
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが1人のとき_自分自身を削除できない
     sign_in admin
     delete :destroy, params: {id: admin.employee.id}
-    assert_response :redirect
-    assert_redirected_to root_path
+
+    assert_redirected_to action: 'index'
+    assert_not admin.employee.reload.deleted?
+    assert flash[:is_error_message]
+    assert_equal ERR_LAST_ACTIVE_ADMIN_DELETE, flash[:notice]
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_自分自身を無効にできる
+    other_admin = User.find(6)
+    other_admin.update!(admin: true)
+
+    sign_in admin
+    post :disable, params: {id: admin.employee.id}
+
+    assert_redirected_to new_user_session_path
+    assert admin.employee.reload.disabled?
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_自分自身を削除できる
+    other_admin = User.find(6)
+    other_admin.update!(admin: true)
+
+    sign_in admin
+    delete :destroy, params: {id: admin.employee.id}
+
+    assert_redirected_to new_user_session_path
+    assert admin.employee.reload.deleted?
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_他のadminを無効にできる
+    other_admin = User.find(6)
+    other_admin.update!(admin: true)
+
+    sign_in admin
+    post :disable, params: {id: other_admin.employee.id}
+
+    assert_redirected_to action: 'index'
+    assert other_admin.employee.reload.disabled?
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_他のadminを削除できる
+    other_admin = User.find(6)
+    other_admin.update!(admin: true)
+
+    sign_in admin
+    delete :destroy, params: {id: other_admin.employee.id}
+
+    assert_redirected_to action: 'index'
+    assert other_admin.employee.reload.deleted?
   end
 
 end

--- a/test/controllers/mm/users_controller_test.rb
+++ b/test/controllers/mm/users_controller_test.rb
@@ -100,19 +100,41 @@ class Mm::UsersControllerTest < ActionController::TestCase
   def test_他人を削除した場合_一覧に遷移すること
     sign_in admin
     delete :destroy, :params => {:id => user.id}
-    assert_response :redirect
     assert_redirected_to :action => 'index'
 
     assert user.reload.deleted?
   end
 
-  def test_本人を削除した場合_ログアウトすること
+  def test_ログイン可能な管理権限を持つユーザーが1人のとき_自分自身を削除できない
     sign_in admin
-    delete :destroy, :params => {:id => admin.id}
+    delete :destroy, params: {id: admin.id}
 
-    assert_response :redirect
+    assert_redirected_to action: 'index'
+    assert_not admin.reload.deleted?
+    assert flash[:is_error_message]
+    assert_equal ERR_LAST_ACTIVE_ADMIN_DELETE, flash[:notice]
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_自分自身を削除できる
+    other_admin = User.find(6)
+    other_admin.update!(admin: true)
+
+    sign_in admin
+    delete :destroy, params: {id: admin.id}
+
     assert_redirected_to new_user_session_path
     assert admin.reload.deleted?
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_他のadminを削除できる
+    other_admin = User.find(6)
+    other_admin.update!(admin: true)
+
+    sign_in admin
+    delete :destroy, params: {id: other_admin.id}
+
+    assert_redirected_to action: 'index'
+    assert other_admin.reload.deleted?
   end
 
   def test_ダイアログ上のエラーメッセージはフォームの項目順に表示されること

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -11,8 +11,8 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   def test_with_active_or_no_employee
-    active_employee = Employee.where(deleted: false).first
-    deleted_employee = Employee.where(deleted: false).second
+    active_employee = Employee.find(1)
+    deleted_employee = Employee.find(7)
     deleted_employee.update!(deleted: true)
     notification1 = Notification.create!(message: "テスト", category: :report_submission, employee: nil)
     notification2 = Notification.create!(message: "テスト", category: :annual_determination, employee: active_employee)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -35,4 +35,9 @@ class UserTest < ActiveSupport::TestCase
     assert_not users(:deleted_employee_user).active_for_authentication?
   end
 
+  def test_would_remove_last_active_admin_非adminはfalse
+    assert_not user.admin?
+    assert_not user.would_remove_last_active_admin?
+  end
+
 end

--- a/test/models/validators/last_active_admin_validator_test.rb
+++ b/test/models/validators/last_active_admin_validator_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class LastActiveAdminValidatorTest < ActiveSupport::TestCase
+  def test_対応外モデルではArgumentError
+    error = assert_raises(ArgumentError) do
+      Validators::LastActiveAdminValidator.new.validate(Bank.new)
+    end
+    assert_equal 'LastActiveAdminValidator: Bank は対応外です', error.message
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが1人のとき_ユーザーを削除できない
+    assert admin.admin?
+    assert admin.active_admin?
+
+    admin.deleted = true
+    assert admin.invalid?
+    assert_equal ERR_LAST_ACTIVE_ADMIN_DELETE, admin.errors[:base].first
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_ユーザーを削除できる
+    other_admin = User.find(6)
+
+    other_admin.update!(admin: true)
+    assert admin.admin?
+    assert other_admin.admin?
+
+    other_admin.deleted = true
+    assert other_admin.valid?
+  end
+
+  def test_非adminのユーザーは削除できる
+    assert_not user.admin?
+
+    user.deleted = true
+    assert user.valid?
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが1人のとき_従業員を無効にできない
+    employee = admin.employee
+
+    assert employee.user.admin?
+    assert employee.user.active_admin?
+
+    employee.disabled = true
+    assert employee.invalid?
+    assert_equal ERR_LAST_ACTIVE_ADMIN_DISABLE, employee.errors[:base].first
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_従業員を無効にできる
+    other_admin = User.find(6)
+
+    other_admin.update!(admin: true)
+    assert admin.admin?
+    assert other_admin.admin?
+
+    other_admin.employee.disabled = true
+    assert other_admin.employee.valid?
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが1人のとき_従業員を削除できない
+    employee = admin.employee
+
+    assert employee.user.admin?
+    assert employee.user.active_admin?
+
+    employee.deleted = true
+    assert employee.invalid?
+    assert_equal ERR_LAST_ACTIVE_ADMIN_DELETE, employee.errors[:base].first
+  end
+
+  def test_ログイン可能な管理権限を持つユーザーが2人のとき_従業員を削除できる
+    other_admin = User.find(6)
+
+    other_admin.update!(admin: true)
+    assert admin.admin?
+    assert other_admin.admin?
+
+    other_admin.employee.deleted = true
+    assert other_admin.employee.valid?
+  end
+
+end


### PR DESCRIPTION
法人内にログイン可能な admin が0人になる操作を LastActiveAdminValidator で拒否する。 mm/users#destroy と mm/employees#disable/#destroy でバリデーションエラーを rescue し flash 表示する。