### PR TITLE
refs #359 Bundler cooldown を導入し Bundler 4.0.14 に更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 7
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -646,7 +646,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 3.4.8p72
+  ruby 3.4.8p72
 
 BUNDLED WITH
-   2.7.2
+  4.0.14

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ $ cd hyacc
 ```
 ### 各種ミドルウェアのインストール
 ```
-$ bundle config without 'itamae'
-$ bundle
+$ bundle config set without itamae
+$ bundle install
 $ bundle exec rake dad:setup
 ```
 ### DBの初期化


### PR DESCRIPTION
### 概要

Gemfile に cooldown（7日）を設定し、Bundler を 4.0.14 に更新する。

### 変更内容

- `Gemfile`: `source` に `cooldown: 7` を追加
- `Gemfile.lock`: `BUNDLED WITH` を 4.0.14 に更新
- `README.md`: Bundler 4 で非推奨のコマンドを修正

### 依存

- [daddy PR](https://github.com/ichylinux/daddy/pull/6)のマージ後、README通りの新規構築で cooldown が有効になる（本 PR より daddy を先にマージしてください）

### 検証

- AlmaLinux 9 の新規環境で README 手順どおりに構築し、Bundler 4.0.14 と cooldown の動作を確認済み