### PR TITLE
refs #371 【UI統一v1】mm/qualifications の一覧・編集・追加を基準ルールに準拠

### DIFF
--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -1,3 +1,6 @@
 class Qualification < ApplicationRecord
   belongs_to :company, inverse_of: 'qualifications'
+
+  validates :name, presence: true
+  validates :allowance, presence: true
 end

--- a/app/views/mm/qualifications/_form.html.erb
+++ b/app/views/mm/qualifications/_form.html.erb
@@ -1,14 +1,14 @@
 <%= form_with model: [:mm, @qualification], data: {remote: true} do |f| %>
   <%= flash_notice %>
 
-  <table class="m-2">
+  <table class="table table-sm mb-0">
     <tr>
       <th><%= f.label :name %></th>
-      <td><%= f.text_field :name %></td>
+      <td><%= f.text_field :name, class: 'form-control form-control-sm', style: 'width: 15em; max-width: 100%;' %></td>
     </tr>
     <tr>
       <th><%= f.label :allowance %></th>
-      <td><%= f.text_field :allowance %></td>
+      <td><%= f.text_field :allowance, class: 'form-control form-control-sm text-end d-inline-block', style: 'width: 8em; max-width: 100%;' %></td>
     </tr>
   </table>
 <% end %>

--- a/app/views/mm/qualifications/index.html.erb
+++ b/app/views/mm/qualifications/index.html.erb
@@ -1,31 +1,28 @@
-<div class="mt-4 col-md-6">
+<div class="m-2 col-md-6">
   <%= flash_notice %>
 
-  <table class="table table-sm table-hover">
+  <table class="table table-striped table-hover">
     <thead>
       <tr>
-        <th style="width: 60%;"><%= Qualification.human_attribute_name :name %></th>
-        <th class="text-center"><%= Qualification.human_attribute_name :allowance %></th>
-        <th></th>
+        <th style="width: 70%;"><%= Qualification.human_attribute_name :name %></th>
+        <th><%= Qualification.human_attribute_name :allowance %></th>
+        <th class="text-center"></th>
       </tr>
     </thead>
     <tbody>
       <% @qualifications.each do |q| %>
         <tr>
-          <td class="align-middle"><%= q.name %></td>
-          <td class="text-center align-middle"><%= to_amount(q.allowance, show_zero: true) %></td>
-          <td class="text-center">
-            <%= link_to '編集', edit_mm_qualification_path(q), class: 'btn btn-small btn-light', remote: true %>
-            <%= link_to '削除', [:mm, q], data: {confirm: "資格 #{q.name} を削除します。\nよろしいですか？"}, class: 'btn btn-small btn-light', method: :delete %>
+          <td><%= q.name %></td>
+          <td class="text-end"><%= to_amount(q.allowance, show_zero: true) %></td>
+          <td class="text-center text-nowrap">
+            <%= link_to '編集', edit_mm_qualification_path(q), class: 'btn btn-sm btn-light', remote: true %>
+            <%= link_to '削除', [:mm, q], data: {confirm: "資格 #{q.name} を削除します。\nよろしいですか？"}, class: 'btn btn-sm btn-light', method: :delete %>
           </td>
         </tr>
       <% end %>
     </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="2" class="align-middle"><%= will_paginate @qualifications %></td>
-        <td class="text-center"><%= link_to '追加', new_mm_qualification_path, class: 'btn btn-light', remote: true %></td>
-      </tr>
-    </tfoot>
   </table>
+
+  <%= will_paginate @qualifications %>
+  <%= link_to '追加', new_mm_qualification_path, class: 'add btn btn-light', remote: true %>
 </div>

--- a/app/views/mm/skills/index.html.erb
+++ b/app/views/mm/skills/index.html.erb
@@ -2,21 +2,21 @@
 <%= flash_notice %>
 
 <% if @skills.present? %>
-  <div class="col-md-8">
+  <div class="col-md-6">
     <table id="skill_container" class="table table-striped table-hover my-4">
       <thead>
         <tr>
           <th style="width: 70%;"><%= Qualification.human_attribute_name :name %></th>
-          <th class="text-center"><%= Skill.human_attribute_name :qualified_on %></th>
-          <th></th>
+          <th><%= Skill.human_attribute_name :qualified_on %></th>
+          <th class="text-center"></th>
         </tr>
       </thead>
       <tbody>
         <% @skills.each do |s| %>
           <tr>
             <td><%= s.qualification.name %></td>
-            <td class="text-center"><%= s.qualified_on || '-' %></td>
-            <td class="text-center">
+            <td><%= s.qualified_on || '-' %></td>
+            <td class="text-center text-nowrap">
               <% if s.new_record? %>
                 <%= link_to '追加', new_mm_skill_path(employee_id: finder.employee_id, qualification_id: s.qualification.id), class: 'btn btn-sm btn-light', remote: true %>
               <% else %>

--- a/test/controllers/mm/qualifications_controller_test.rb
+++ b/test/controllers/mm/qualifications_controller_test.rb
@@ -31,4 +31,28 @@ class Mm::QualificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @expected.name, @actual.name
     assert_equal @expected.allowance, @actual.allowance
   end
+
+  def test_登録_入力エラー
+    assert_no_difference 'Qualification.count' do
+      post mm_qualifications_path, xhr: true, params: {
+        qualification: {name: '', allowance: ''}
+      }
+    end
+
+    assert_response :success
+    assert_template :new
+    assert assigns(:qualification).errors[:name].present?
+    assert assigns(:qualification).errors[:allowance].present?
+  end
+
+  def test_更新_入力エラー
+    patch mm_qualification_path(qualification), xhr: true, params: {
+      qualification: {name: '', allowance: ''}
+    }
+
+    assert_response :success
+    assert_template :edit
+    assert assigns(:qualification).errors[:name].present?
+    assert assigns(:qualification).errors[:allowance].present?
+  end
 end

--- a/test/models/qualification_test.rb
+++ b/test/models/qualification_test.rb
@@ -1,7 +1,19 @@
 require 'test_helper'
 
 class QualificationTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def test_validates_name_presence
+    q = company.qualifications.build(name: '', allowance: 0)
+
+    assert_not q.valid?
+    assert q.errors[:name].present?
+  end
+
+  def test_validates_allowance_presence
+    q = company.qualifications.build(name: 'テスト資格', allowance: nil)
+
+    assert_not q.valid?
+    assert q.errors[:allowance].present?
+  end
+
 end


### PR DESCRIPTION
- 一覧を table-striped table-hover に統一し、手当列の右寄せ・操作列のボタン化・追加ボタン配置を customers 型に揃えた。 
- 編集・追加フォームを table table-sm とform-control-sm に統一した。 
- 資格名・手当単価の必須バリデーションを追加し、テストも作成、エラー表示については画面で確認済み。
- mm/skills の一覧グリッド幅と列寄せを qualifications に揃える。